### PR TITLE
fix: correct fbq 4th-arg usage, layout stub guard, Purchase event value

### DIFF
--- a/app/checkout/success/page.tsx
+++ b/app/checkout/success/page.tsx
@@ -119,7 +119,7 @@ export default function CheckoutSuccessPage() {
       await trackFbEvent(
         "Purchase",
         {
-          value: total,
+          value: parsed?.order.total ?? total,
           currency: "USD",
           content_type: "product",
           content_ids: items.map((i) => i.product.id),
@@ -128,11 +128,9 @@ export default function CheckoutSuccessPage() {
             quantity: i.quantity,
             item_price: i.product.price,
           })),
-          order_id: id,
-          eventID: `purchase_${id}`,
         },
         {
-          // Customer information for advanced matching (will be SHA-256 hashed)
+          // Raw PII — hashed by trackFbEvent before reaching fbq
           em: parsed?.customer.email,
           ph: parsed?.customer.phone,
           fn: parsed?.customer.firstName,
@@ -141,6 +139,8 @@ export default function CheckoutSuccessPage() {
           st: parsed?.shipping.state,
           zp: parsed?.shipping.zip,
         },
+        // eventID lands in fbq's 4th arg for Conversions API deduplication
+        id ?? undefined,
       )
 
       /* -------------------------- Clear cart & cleanup ----------------------- */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,6 +17,8 @@ export const metadata: Metadata = {
     generator: 'v0.dev'
 }
 
+const PIXEL_ID = process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID || '614139101427697'
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -28,17 +30,20 @@ export default function RootLayout({
         <script
           dangerouslySetInnerHTML={{
             __html: `
-              if(!window.fbq){window.fbq=function(){window.fbq.callMethod?window.fbq.callMethod.apply(window.fbq,arguments):window.fbq.queue.push(arguments)};if(!window._fbq)window._fbq=window.fbq;}
-              window.fbq.push=window.fbq;
-              window.fbq.loaded=!0;
-              window.fbq.version='2.0';
-              window.fbq.queue=[];
-              window.fbq('init', '${process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID}');
-              window.fbq('track', 'PageView');
+              if(!window.fbq){
+                window.fbq=function(){window.fbq.callMethod?window.fbq.callMethod.apply(window.fbq,arguments):window.fbq.queue.push(arguments)};
+                if(!window._fbq)window._fbq=window.fbq;
+                window.fbq.push=window.fbq;
+                window.fbq.loaded=!0;
+                window.fbq.version='2.0';
+                window.fbq.queue=[];
+              }
+              window.fbq('init','${PIXEL_ID}');
+              window.fbq('track','PageView');
             `,
           }}
         />
-        <FacebookPixel />
+        <FacebookPixel pixelId={PIXEL_ID} />
         <CartProvider>
           <div className="flex min-h-screen flex-col">
             <SkipToContent />

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -54,9 +54,12 @@ function flushFbqQueue() {
     const fbq = window.fbq as FbqFn
     fbqEventQueue.forEach(({ event, data, options }) => {
       try {
-        // Combine data and options into a single object for fbq
-        const mergedData = { ...data, ...options }
-        fbq("track", event, mergedData)
+        // Pass options as the 4th fbq arg — never merge into event data.
+        // Meta reads advanced matching (em, ph, fn, ln) and eventID only
+        // from the 4th argument; values in the 3rd arg are silently ignored.
+        options
+          ? fbq("track", event, data, options)
+          : fbq("track", event, data)
       } catch (error) {
         console.error("Facebook Pixel tracking error while flushing queue:", error)
       }
@@ -73,37 +76,43 @@ function flushFbqQueue() {
 
 /**
  * Track an event with Facebook Pixel, or queue it until fbq is loaded.
- * Supports Meta Pixel advanced matching with automatic SHA-256 hashing.
  *
- * @param event - Event name (e.g., "Purchase", "AddToCart")
- * @param data - Event data (content_ids, contents, value, currency, etc.)
- * @param advancedMatching - User data for advanced matching (will be SHA-256 hashed)
+ * @param event            - Event name (e.g. "Purchase", "AddToCart")
+ * @param data             - Event parameters — 3rd fbq arg
+ * @param advancedMatching - Raw (unhashed) user PII. Hashed here with SHA-256
+ *                           and passed as the 4th fbq arg where Meta reads it.
+ *                           Never put these in the event data (3rd arg) —
+ *                           Meta ignores them there.
+ * @param eventID          - Deduplication ID for Conversions API — also 4th arg.
  */
 export const trackFbEvent = async (
   event: string,
   data?: EventOptions,
   advancedMatching?: AdvancedMatchingData,
+  eventID?: string,
 ) => {
   if (typeof window === "undefined") return
 
-  // Hash advanced matching fields
-  let hashedMatching: Record<string, string> = {}
-  if (advancedMatching) {
+  // Build the 4th-arg options object: hashed PII + eventID
+  let fbqOptions: Record<string, string> | undefined
+  if (advancedMatching || eventID) {
+    fbqOptions = {}
+    if (eventID) fbqOptions.eventID = eventID
     try {
-      if (advancedMatching.em) hashedMatching.em = await sha256Hex(advancedMatching.em.toLowerCase().trim())
-      if (advancedMatching.ph) hashedMatching.ph = await sha256Hex(advancedMatching.ph.replace(/\D/g, ""))
-      if (advancedMatching.fn) hashedMatching.fn = await sha256Hex(advancedMatching.fn.toLowerCase().trim())
-      if (advancedMatching.ln) hashedMatching.ln = await sha256Hex(advancedMatching.ln.toLowerCase().trim())
-      if (advancedMatching.ct) hashedMatching.ct = await sha256Hex(advancedMatching.ct.toLowerCase().trim())
-      if (advancedMatching.st) hashedMatching.st = await sha256Hex(advancedMatching.st.toLowerCase().trim())
-      if (advancedMatching.zp) hashedMatching.zp = await sha256Hex(advancedMatching.zp.toLowerCase().replace(/\s/g, ""))
-      if (advancedMatching.country) hashedMatching.country = await sha256Hex(advancedMatching.country.toLowerCase())
+      if (advancedMatching?.em) fbqOptions.em = await sha256Hex(advancedMatching.em.trim().toLowerCase())
+      if (advancedMatching?.ph) fbqOptions.ph = await sha256Hex(advancedMatching.ph.replace(/\D/g, ""))
+      if (advancedMatching?.fn) fbqOptions.fn = await sha256Hex(advancedMatching.fn.trim().toLowerCase())
+      if (advancedMatching?.ln) fbqOptions.ln = await sha256Hex(advancedMatching.ln.trim().toLowerCase())
+      if (advancedMatching?.ct) fbqOptions.ct = await sha256Hex(advancedMatching.ct.trim().toLowerCase())
+      if (advancedMatching?.st) fbqOptions.st = await sha256Hex(advancedMatching.st.trim().toLowerCase())
+      if (advancedMatching?.zp) fbqOptions.zp = await sha256Hex(advancedMatching.zp.replace(/\s/g, ""))
+      if (advancedMatching?.country) fbqOptions.country = await sha256Hex(advancedMatching.country.trim().toLowerCase())
     } catch (error) {
       console.error("Error hashing advanced matching data:", error)
     }
   }
 
-  // Clean contents array to only include allowed fields
+  // Clean contents array to only include Meta-spec fields
   const cleanedData = { ...data }
   if (cleanedData.contents && Array.isArray(cleanedData.contents)) {
     cleanedData.contents = cleanedData.contents.map((item: any) => ({
@@ -113,25 +122,23 @@ export const trackFbEvent = async (
     }))
   }
 
-  // Merge hashed matching data with event data
-  const eventOptions = { ...cleanedData, user_data: hashedMatching }
-
   if (typeof window.fbq === "function") {
     const fbq = window.fbq as FbqFn
     try {
-      fbq("track", event, eventOptions)
+      fbqOptions
+        ? fbq("track", event, cleanedData, fbqOptions)
+        : fbq("track", event, cleanedData)
     } catch (error) {
       console.error("Facebook Pixel tracking error:", error)
     }
   } else {
-    // fbq not ready -- enqueue the event
-    fbqEventQueue.push({ event, options: eventOptions })
+    // fbq not ready — enqueue with data and options kept separate
+    fbqEventQueue.push({ event, data: cleanedData, options: fbqOptions })
 
     // Set up retry to flush queue when fbq becomes available
     if (!flushTimeout) {
       flushTimeout = setTimeout(() => {
         flushFbqQueue()
-        // Retry up to 5 times
         let retries = 0
         const retryInterval = setInterval(() => {
           if (typeof window !== "undefined" && typeof window.fbq === "function") {


### PR DESCRIPTION
lib/analytics.ts
- trackFbEvent now accepts eventID as a 4th param and builds a proper fbqOptions object with hashed PII + eventID, passed as fbq's 4th arg. Previously everything was merged into the event data under user_data — Meta ignores advanced matching there.
- flushFbqQueue updated to match: passes options as 4th arg, never merges.

app/layout.tsx
- Move fbq.push/loaded/version/queue=[] inside the if(!window.fbq) block so a duplicate script execution can't wipe a populated queue.
- Extract PIXEL_ID const with fallback so init never fires with 'undefined'.
- Pass pixelId prop to FacebookPixel component.

app/checkout/success/page.tsx
- value: parsed?.order.total ?? total — includes tax (was missing it).
- Remove order_id (non-standard) and eventID from event data; pass id as 4th arg to trackFbEvent so it reaches fbq's 4th-arg options object.